### PR TITLE
Fix code climate and coverage badges

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,7 @@
+---
+engines:
+  fixme:
+    enabled: true
+ratings:
+  paths: []
+exclude_paths: []

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,5 +3,8 @@ engines:
   fixme:
     enabled: true
 ratings:
-  paths: []
+  paths:
+    - "app/**/*"
+    - "lib/**/*"
+    - "**.rb"
 exclude_paths: []

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 [ ![Build Status](https://app.codeship.com/projects/05f88220-bf12-0134-b657-7a625a3fabd4/status?branch=master)](https://app.codeship.com/projects/196490)
+![Code Climate](https://codeclimate.com/github/sehrmann/SchwamIt.png)
 [![Coverage Status](https://coveralls.io/repos/github/sehrmann/SchwamIt/badge.svg?branch=master)](https://coveralls.io/github/sehrmann/SchwamIt?branch=master)
-![Coverage Status](https://coveralls.io/repos/sehrmann/SchwamIt/badge.png)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 [ ![Build Status](https://app.codeship.com/projects/05f88220-bf12-0134-b657-7a625a3fabd4/status?branch=master)](https://app.codeship.com/projects/196490)
-![Code Climate](https://codeclimate.com/github/sehrmann/SchwamIt.png)
+[![Coverage Status](https://coveralls.io/repos/github/sehrmann/SchwamIt/badge.svg?branch=master)](https://coveralls.io/github/sehrmann/SchwamIt?branch=master)
 ![Coverage Status](https://coveralls.io/repos/sehrmann/SchwamIt/badge.png)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 [ ![Build Status](https://app.codeship.com/projects/05f88220-bf12-0134-b657-7a625a3fabd4/status?branch=master)](https://app.codeship.com/projects/196490)
-![Code Climate](https://codeclimate.com/github/sehrmann/SchwamIt.png)
+[![Code Climate](https://codeclimate.com/github/sehrmann/SchwamIt/badges/gpa.svg)](https://codeclimate.com/github/sehrmann/SchwamIt)
 [![Coverage Status](https://coveralls.io/repos/github/sehrmann/SchwamIt/badge.svg?branch=master)](https://coveralls.io/github/sehrmann/SchwamIt?branch=master)


### PR DESCRIPTION
 * fixed link in ReadMe for coverage badge
 * added `.codeclimate.yml` and configured it.
 * configured webhook to code climate to get the gpa badge to work. This was done through the websites rather than in the code.