### PR TITLE
Create item delete

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,6 +37,12 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    @item = Item.find(params[:id])
+    @item.destroy
+    redirect_to items_path
+  end
+
   private
 
   def item_params

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,3 +1,5 @@
 <h1>Edit <%= @title %></h1>
 
 <%= render 'form' %>
+
+<%= link_to 'Delete', @item, method: :delete, data: { confirm: "Are you sure?" } %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,4 +4,5 @@
 <p><%= @item.description %></p>
 
 <%= link_to "Edit", edit_item_path %>
+<%= link_to 'Delete', @item, method: :delete, data: { confirm: "Are you sure?" } %>
 <%= link_to "Back", items_path %>

--- a/spec/features/support/factories.rb
+++ b/spec/features/support/factories.rb
@@ -1,0 +1,5 @@
+
+
+FactoryGirl.define do
+  
+end

--- a/spec/features/user_deletes_item_spec.rb
+++ b/spec/features/user_deletes_item_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+feature "User deletes an existing item" do
+  before(:each) do
+    visit root_path
+    click_link 'Sign Up'
+    fill_in 'Username', with: 'birdman'
+    fill_in 'Email', with: 'birdie@gmail.com'
+    fill_in 'user_password', with: 'password'
+    fill_in 'Confirm Password', with: 'password'
+    click_button 'Sign Up'
+
+    visit new_item_path
+    fill_in "Title", with: "Pokemon"
+    fill_in "Description", with: "Gotta Catch 'Em All"
+    click_button "Create Item"
+
+    visit items_path
+    click_link 'Pokemon'
+  end
+
+  scenario "users can choose to delete from the item's show page" do
+    expect(find_link('Delete').visible?).to eq true
+  end
+
+  scenario "users can succesfully delete from the item's show page" do
+    click_link 'Delete'
+
+    expect(page).to have_no_content "Pokemon"
+    expect(page).to have_current_path(items_path)
+  end
+
+  scenario "users can choose to delete from the item's edit page" do
+    click_link 'Edit'
+
+    expect(find_link('Delete').visible?).to eq true
+  end
+
+  scenario "users can succesfully delete from the item's edit page" do
+    click_link 'Edit'
+    click_link 'Delete'
+
+    expect(page).to have_no_content "Pokemon"
+    expect(page).to have_current_path(items_path)
+  end
+end


### PR DESCRIPTION
-Created destroy control action in the items controller and added link to item show and edit pages.
-Added feature tests for both available links.