### PR TITLE
Changed 'Edit Account' to 'Account Settings', fixed associated tests

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,7 @@
       <ul class="right">
         <% if user_signed_in? %>
           <li class='right-item'> <%= link_to 'Sign Out', destroy_user_session_path, :method => :delete %> </li>
-          <li class='right-item'> <%= link_to 'Edit Account', edit_user_registration_path %> </li>
+          <li class='right-item'> <%= link_to 'Account Settings', edit_user_registration_path %> </li>
         <% else %>
           <li class='right-item'> <%= link_to 'Sign Up', new_user_registration_path %> </li>
           <li class='right-item'> <%= link_to 'Sign In', new_user_session_path %> </li>

--- a/spec/features/edit_account_spec.rb
+++ b/spec/features/edit_account_spec.rb
@@ -10,10 +10,10 @@ feature "user edits their account" do
     fill_in 'user_password', with: 'password'
     fill_in 'Confirm Password', with: 'password'
     click_button 'Sign Up'
-    click_link 'Edit Account'
+    click_link 'Account Settings'
   end
 
-  scenario "user can navigate to the edit account page" do
+  scenario "user can navigate to the Account Settings page" do
     expect(page).to have_content "Edit User"
   end
 
@@ -27,7 +27,7 @@ feature "user edits their account" do
 
 
     expect(page).to have_content "Your account has been updated successfully"
-    click_link 'Edit Account'
+    click_link 'Account Settings'
     expect(find_field("Username").value).to eq "catman"
     expect(find_field("Electronic Mail").value).to eq "fishman@gmail.com"
     click_link 'Sign Out'


### PR DESCRIPTION
* Visitors can only view the index and show pages
* Logged in users can do the above plus create new items and edit/delete their own items
* Admins can do the above and edit/delete ALL items

* Fixed conflict between `Edit` and `Edit Account` links by changing `Edit Account` to `Account Settings`